### PR TITLE
Switch default Ollama model to Gemma3

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -53,11 +53,11 @@ Ollama CLIをインストールします。
 curl -fsSL https://ollama.com/install.sh | sh
 ```
 
-インストール後、Ollamaサーバーを起動し、モデルを取得します (サンプルでは`qwen3:0.6b`を使用)。
+インストール後、Ollamaサーバーを起動し、モデルを取得します (サンプルでは`gemma3:latest`を使用)。
 
 ```bash
 ollama serve &                 # ローカルOllamaサーバーを起動
-ollama pull qwen3:0.6b         # 推論用モデルをダウンロード
+ollama pull gemma3:latest      # 推論用モデルをダウンロード
 ```
 
 サーバーが `http://localhost:11434` で起動していれば、次のサンプルを試せます。

--- a/README.md
+++ b/README.md
@@ -186,11 +186,11 @@ curl -fsSL https://ollama.com/install.sh | sh
 ```
 
 Once installed, start the Ollama server and pull a model (the examples use
-`qwen3:0.6b` by default):
+`gemma3:latest` by default):
 
 ```bash
 ollama serve &                 # start the local Ollama server
-ollama pull qwen3:0.6b         # download a model for generation
+ollama pull gemma3:latest      # download a model for generation
 ```
 
 With the server running at `http://localhost:11434` you can try an example that

--- a/examples/basic_modules/llm.py
+++ b/examples/basic_modules/llm.py
@@ -10,7 +10,7 @@ config = LLMConfigFactory.model_validate(
     {
         "backend": "ollama",
         "config": {
-            "model_name_or_path": "qwen3:0.6b",
+            "model_name_or_path": "gemma3:latest",
             "temperature": 0.8,
             "max_tokens": 1024,
             "top_p": 0.9,
@@ -30,7 +30,7 @@ print("==" * 20)
 # Scenario 2: Using Pydantic model directly
 
 config = OllamaLLMConfig(
-    model_name_or_path="qwen3:0.6b",
+    model_name_or_path="gemma3:latest",
     temperature=0.8,
     max_tokens=1024,
     top_p=0.9,

--- a/examples/basic_modules/tree_textual_memory_reasoner.py
+++ b/examples/basic_modules/tree_textual_memory_reasoner.py
@@ -27,7 +27,7 @@ config = LLMConfigFactory.model_validate(
     {
         "backend": "ollama",
         "config": {
-            "model_name_or_path": "qwen3:0.6b",
+            "model_name_or_path": "gemma3:latest",
             "temperature": 0.7,
             "max_tokens": 1024,
         },

--- a/examples/basic_modules/tree_textual_memory_reranker.py
+++ b/examples/basic_modules/tree_textual_memory_reranker.py
@@ -27,7 +27,7 @@ config = LLMConfigFactory.model_validate(
     {
         "backend": "ollama",
         "config": {
-            "model_name_or_path": "qwen3:0.6b",
+            "model_name_or_path": "gemma3:latest",
             "temperature": 0.7,
             "max_tokens": 1024,
         },

--- a/examples/basic_modules/tree_textual_memory_task_goal_parser.py
+++ b/examples/basic_modules/tree_textual_memory_task_goal_parser.py
@@ -10,7 +10,7 @@ config = LLMConfigFactory.model_validate(
     {
         "backend": "ollama",
         "config": {
-            "model_name_or_path": "qwen3:0.6b",
+            "model_name_or_path": "gemma3:latest",
             "temperature": 0.7,
             "max_tokens": 1024,
             "remove_think_prefix": True,

--- a/examples/core_memories/general_textual_memory.py
+++ b/examples/core_memories/general_textual_memory.py
@@ -8,7 +8,7 @@ config = MemoryConfigFactory(
         "extractor_llm": {
             "backend": "ollama",
             "config": {
-                "model_name_or_path": "qwen3:0.6b",
+                "model_name_or_path": "gemma3:latest",
                 "temperature": 0.0,
                 "remove_think_prefix": True,
                 "max_tokens": 8192,

--- a/examples/core_memories/naive_textual_memory.py
+++ b/examples/core_memories/naive_textual_memory.py
@@ -10,7 +10,7 @@ config = MemoryConfigFactory(
         "extractor_llm": {
             "backend": "ollama",
             "config": {
-                "model_name_or_path": "qwen3:0.6b",
+                "model_name_or_path": "gemma3:latest",
                 "temperature": 0.0,
                 "remove_think_prefix": True,
             },

--- a/examples/data/config/mem_scheduler/mem_cube_config.yaml
+++ b/examples/data/config/mem_scheduler/mem_cube_config.yaml
@@ -6,14 +6,14 @@ text_mem:
     extractor_llm:
       backend: "ollama"
       config:
-        model_name_or_path: "qwen3:0.6b"
+        model_name_or_path: "gemma3:latest"
         temperature: 0.0
         remove_think_prefix: true
         max_tokens: 8192
     dispatcher_llm:
       backend: "ollama"
       config:
-        model_name_or_path: "qwen3:0.6b"
+        model_name_or_path: "gemma3:latest"
         temperature: 0.0
         remove_think_prefix: true
         max_tokens: 8192

--- a/examples/data/config/mem_scheduler/memos_config_w_scheduler.yaml
+++ b/examples/data/config/mem_scheduler/memos_config_w_scheduler.yaml
@@ -12,7 +12,7 @@ mem_reader:
     llm:
       backend: "ollama"
       config:
-        model_name_or_path: "qwen3:0.6b"
+        model_name_or_path: "gemma3:latest"
         remove_think_prefix: true
         temperature: 0.8
         max_tokens: 1024

--- a/examples/data/config/mem_scheduler/memos_config_wo_scheduler.yaml
+++ b/examples/data/config/mem_scheduler/memos_config_wo_scheduler.yaml
@@ -12,7 +12,7 @@ mem_reader:
     llm:
       backend: "ollama"
       config:
-        model_name_or_path: "qwen3:0.6b"
+        model_name_or_path: "gemma3:latest"
         remove_think_prefix: true
         temperature: 0.8
         max_tokens: 1024

--- a/examples/mem_chat/chat_w_generated_cube_explicit_memory_only.py
+++ b/examples/mem_chat/chat_w_generated_cube_explicit_memory_only.py
@@ -12,7 +12,7 @@ mem_chat_config = MemChatConfigFactory.model_validate(
             "chat_llm": {
                 "backend": "ollama",
                 "config": {
-                    "model_name_or_path": "qwen3:1.7b",
+                    "model_name_or_path": "gemma3:latest",
                     "temperature": 0.0,
                     "remove_think_prefix": True,
                     "max_tokens": 4096,
@@ -39,7 +39,7 @@ config = GeneralMemCubeConfig.model_validate(
                 "extractor_llm": {
                     "backend": "ollama",
                     "config": {
-                        "model_name_or_path": "qwen3:1.7b",
+                        "model_name_or_path": "gemma3:latest",
                         "temperature": 0.0,
                         "remove_think_prefix": True,
                         "max_tokens": 8192,
@@ -48,7 +48,7 @@ config = GeneralMemCubeConfig.model_validate(
                 "dispatcher_llm": {
                     "backend": "ollama",
                     "config": {
-                        "model_name_or_path": "qwen3:1.7b",
+                        "model_name_or_path": "gemma3:latest",
                         "temperature": 0.0,
                         "remove_think_prefix": True,
                         "max_tokens": 8192,

--- a/examples/mem_cube/load_lazily.py
+++ b/examples/mem_cube/load_lazily.py
@@ -25,7 +25,7 @@ mem_cube.text_mem = MemoryFactory.from_config(
             "extractor_llm": {
                 "backend": "ollama",
                 "config": {
-                    "model_name_or_path": "qwen3:0.6b",
+                    "model_name_or_path": "gemma3:latest",
                     "temperature": 0.0,
                     "remove_think_prefix": True,
                 },

--- a/examples/mem_os/chat_w_generated_cube_explicit_memory.py
+++ b/examples/mem_os/chat_w_generated_cube_explicit_memory.py
@@ -22,7 +22,7 @@ config = {
             "llm": {
                 "backend": "ollama",
                 "config": {
-                    "model_name_or_path": "qwen3:0.6b",
+                    "model_name_or_path": "gemma3:latest",
                     "temperature": 0.0,
                     "remove_think_prefix": True,
                     "max_tokens": 8192,
@@ -66,7 +66,7 @@ config = GeneralMemCubeConfig.model_validate(
                 "extractor_llm": {
                     "backend": "ollama",
                     "config": {
-                        "model_name_or_path": "qwen3:1.7b",
+                        "model_name_or_path": "gemma3:latest",
                         "temperature": 0.0,
                         "remove_think_prefix": True,
                         "max_tokens": 8192,
@@ -75,7 +75,7 @@ config = GeneralMemCubeConfig.model_validate(
                 "dispatcher_llm": {
                     "backend": "ollama",
                     "config": {
-                        "model_name_or_path": "qwen3:1.7b",
+                        "model_name_or_path": "gemma3:latest",
                         "temperature": 0.0,
                         "remove_think_prefix": True,
                         "max_tokens": 8192,

--- a/src/memos/llms/ollama.py
+++ b/src/memos/llms/ollama.py
@@ -21,7 +21,7 @@ class OllamaLLM(BaseLLM):
 
         # Default model if not specified
         if not self.config.model_name_or_path:
-            self.config.model_name_or_path = "llama3.1:latest"
+            self.config.model_name_or_path = "gemma3:latest"
 
         # Initialize ollama client
         self.client = Client(host=self.api_base)


### PR DESCRIPTION
## Summary
- update README docs to use `gemma3:latest`
- set default Ollama LLM model to Gemma3
- update example configs and scripts to reference Gemma3 instead of Qwen3

## Testing
- `pytest tests/llms/test_ollama.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6870d7b3f1ac832396c505fdefb69d5a