### PR TITLE
Fix local path handling for MemCube registration

### DIFF
--- a/src/memos/mem_os/core.py
+++ b/src/memos/mem_os/core.py
@@ -380,11 +380,20 @@ class MOSCore:
             mem_cube_id = mem_cube_name_or_path
 
         if mem_cube_id in self.mem_cubes:
-            logger.info(f"MemCube with ID {mem_cube_id} already in MOS, skip install.")
+            logger.info(
+                f"MemCube with ID {mem_cube_id} already in MOS, skip install."
+            )
         else:
-            if os.path.exists(mem_cube_name_or_path):
-                self.mem_cubes[mem_cube_id] = GeneralMemCube.init_from_dir(mem_cube_name_or_path)
+            path_obj = Path(mem_cube_name_or_path)
+            if path_obj.exists():
+                self.mem_cubes[mem_cube_id] = GeneralMemCube.init_from_dir(
+                    mem_cube_name_or_path
+                )
             else:
+                if path_obj.is_absolute() or path_obj.drive:
+                    raise FileNotFoundError(
+                        f"Local MemCube path {mem_cube_name_or_path} does not exist."
+                    )
                 logger.warning(
                     f"MemCube {mem_cube_name_or_path} does not exist, try to init from remote repo."
                 )

--- a/tests/mem_os/test_memos_core.py
+++ b/tests/mem_os/test_memos_core.py
@@ -285,7 +285,7 @@ class TestMOSMemoryOperations:
         mock_user_manager.get_cube.return_value = None  # Cube doesn't exist
 
         with patch("memos.mem_os.core.GeneralMemCube") as mock_general_cube:
-            mock_general_cube.init_from_dir.return_value = mock_mem_cube
+        mock_general_cube.init_from_dir.return_value = mock_mem_cube
 
             mos = MOSCore(MOSConfig(**mock_config))
 
@@ -294,6 +294,32 @@ class TestMOSMemoryOperations:
 
             assert "test_cube_1" in mos.mem_cubes
             mock_general_cube.init_from_dir.assert_called_once_with("test_cube_path")
+
+    @patch("memos.mem_os.core.UserManager")
+    @patch("memos.mem_os.core.MemReaderFactory")
+    @patch("memos.mem_os.core.LLMFactory")
+    def test_register_mem_cube_missing_local_path(
+        self,
+        mock_llm_factory,
+        mock_reader_factory,
+        mock_user_manager_class,
+        mock_config,
+        mock_llm,
+        mock_mem_reader,
+        mock_user_manager,
+        mock_mem_cube,
+    ):
+        """Test registering a MemCube with an invalid local path."""
+        mock_llm_factory.from_config.return_value = mock_llm
+        mock_reader_factory.from_config.return_value = mock_mem_reader
+        mock_user_manager_class.return_value = mock_user_manager
+        mock_user_manager.get_cube.return_value = None
+
+        mos = MOSCore(MOSConfig(**mock_config))
+
+        with patch("pathlib.Path.exists", return_value=False):
+            with pytest.raises(FileNotFoundError):
+                mos.register_mem_cube("/absent/path/to/cube")
 
     @patch("memos.mem_os.core.UserManager")
     @patch("memos.mem_os.core.MemReaderFactory")


### PR DESCRIPTION
## Summary
- handle missing local paths in `register_mem_cube`
- test new error path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6871c387da308323aa5bf2824d786667